### PR TITLE
add pull/build for s-lang as part of build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+.DS_Store
+.eunit
+logs
+/ebin/*
+*~
+.#*
+*.beam
+/log/*
+/deps/*
+/doc/*
+*.o

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+REBAR=rebar
+
+all: get-deps compile
+get-deps:
+	$(REBAR) get-deps
+compile:
+	$(REBAR) compile
+clean:
+	$(REBAR) clean
+	rm -rf ebin/*.config

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -1,20 +1,16 @@
-PRIV := ../priv
+LINUX=$(shell uname | grep Linux | wc -l | xargs echo)
+DEPS=../deps
 
-# sudo apt-get install libslang2-pic
+ERLANG_HOME=/usr/local/lib/erlang
+SLANG_FLAGS=
+INSTALL_PATH=$(CURDIR)/../deps/slang
 
-LIBS := /usr/lib/libslang_pic.a
+all: $(DEPS)/slang-2.2.4/src/objs/libslang.a
 
-ERL_CFLAGS := $(shell erl -noinput -eval \
-			'io:format("-I~s/erts-~s/include", [code:root_dir(), erlang:system_info(version)]), halt(0)')
+$(DEPS)/slang:
+	@mkdir $(DEPS); cd $(DEPS) ; \
+	curl ftp://ftp.fu-berlin.de/pub/unix/misc/slang/v2.2/slang-2.2.4.tar.gz | tar xzf -
 
-override CFLAGS += -Wall -fPIC $(ERL_CFLAGS)
-override CPPFLAGS += -I$(LIBSLANG)/src $(ERL_CPPFLAGS)
-override LDFLAGS += -fpic -lslang_pic
-
-all : $(PRIV)/eslang_drv.so
-
-$(PRIV)/eslang_drv.so : slang_drv.o
-	$(CC) -shared $(LDFLAGS) -o $@ $^ $(LIBS)
-
-clean:
-	$(RM) -f *.o $(PRIV)/eslang_drv.so
+$(DEPS)/slang-2.2.4/src/objs/libslang.a: $(DEPS)/slang
+	@cd $(DEPS)/slang-2.2.4 && ./configure --prefix $(INSTALL_PATH) \
+	&& make static && make install-static

--- a/rebar.config
+++ b/rebar.config
@@ -1,1 +1,10 @@
-{pre_hooks, [{compile, "sh -c '(cd c_src; make;)'"}]}.
+{port_env,
+ [{"DRV_LDFLAGS","deps/slang/lib/libslang.a -shared $ERL_LDFLAGS -lstdc++ -luuid"},
+  {"darwin", "DRV_LDFLAGS", "deps/slang/lib/libslang.a -bundle -flat_namespace -undefined suppress $ERL_LDFLAGS"},
+  {"netbsd", "DRV_LDFLAGS", "deps/slang/lib/libslang.a -shared $ERL_LDFLAGS -lstdc++"},
+  {"DRV_CFLAGS","-Ic_src -Ideps/slang/include -g -Wall -fPIC $ERL_CFLAGS"}]}.
+
+{port_specs, [{"priv/eslang_drv.so", ["c_src/*.c"]}]}.
+
+{pre_hooks,[{compile,"make -C c_src"},
+            {clean, "make -C c_src clean"}]}.


### PR DESCRIPTION
The existing eslang build depends on "$ sudo apt-get install libslang2-pic" so it doesn't work smoothly on Mac OS. This pull request makes build procedure for eslang driver more generic as it auto pulls/builds s-lang binaries from the source, so no extra platform dependent steps are required to get the dependencies in order.
